### PR TITLE
Search/Filter buttons are needed for applying filtering on the grid

### DIFF
--- a/app/code/community/Clean/SqlReports/Block/Adminhtml/Report/View/Grid.php
+++ b/app/code/community/Clean/SqlReports/Block/Adminhtml/Report/View/Grid.php
@@ -14,15 +14,6 @@ class Clean_SqlReports_Block_Adminhtml_Report_View_Grid extends Mage_Adminhtml_B
         $this->addExportType('*/*/exportCsv', $this->__('CSV'));
     }
 
-    protected function _prepareLayout()
-    {
-        parent::_prepareLayout();
-        $this->unsetChild('search_button');
-        $this->unsetChild('reset_filter_button');
-
-        return $this;
-    }
-
     /**
      * @return Clean_SqlReports_Model_Report
      */


### PR DESCRIPTION
When a grid configuration is provided with filterable fields, these buttons are needed to apply the search parameters. I currently work around this by making my own grid class without the buttons removed and using a rewrite, but I feel it would be better if they were there by default (unless there's a reason these are removed).
