### PR TITLE
Add save and continue edit button

### DIFF
--- a/app/code/community/Clean/SqlReports/Block/Adminhtml/Report/Edit.php
+++ b/app/code/community/Clean/SqlReports/Block/Adminhtml/Report/Edit.php
@@ -13,6 +13,7 @@ class Clean_SqlReports_Block_Adminhtml_Report_Edit extends Mage_Adminhtml_Block_
         parent::__construct();
 
         $this->_addDeleteButton();
+        $this->_addSaveAndContinueEditButton();
 
         $this->_removeButton('reset');
     }
@@ -26,5 +27,15 @@ class Clean_SqlReports_Block_Adminhtml_Report_Edit extends Mage_Adminhtml_Block_
             'onclick'   => "deleteConfirm('$confirmText', '$deleteUrl');",
             'class'     => 'save',
         ));
+    }
+
+    protected function _addSaveAndContinueEditButton()
+    {
+        $url = $this->getSaveUrl() . 'back/edit';
+        $this->_addButton('saveandcontinue', array(
+            'label'     => 'Save and Continue Edit',
+            'onclick'   => 'editForm.submit(\'' . $url . '\')',
+            'class'     => 'save'
+        ), -100);
     }
 }

--- a/app/code/community/Clean/SqlReports/controllers/Adminhtml/ReportController.php
+++ b/app/code/community/Clean/SqlReports/controllers/Adminhtml/ReportController.php
@@ -59,6 +59,11 @@ class Clean_SqlReports_Adminhtml_ReportController extends Mage_Adminhtml_Control
 
         Mage::getSingleton('adminhtml/session')->addSuccess($this->__("Saved report: %s", $report->getTitle()));
 
+        if ($this->getRequest()->getParam('back')) {
+            $this->_redirect('*/*/edit', array('report_id' => $report->getId()));
+            return $this;
+        }
+
         $this->_redirect('*/*');
 
         return $this;


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/4132322/10866678/37b260d8-8011-11e5-93cf-9d8ac0d7c7b2.png)

Resolves #37 

I thought it might also make sense to use the `delete` class for the delete button (currently using `save`), but wasn't sure if there was a decision made to style it with the `save` checkmark, so I didn't change it for this PR.