### PR TITLE
Fix class on delete button

### DIFF
--- a/app/code/community/Clean/SqlReports/Block/Adminhtml/Report/Edit.php
+++ b/app/code/community/Clean/SqlReports/Block/Adminhtml/Report/Edit.php
@@ -25,7 +25,7 @@ class Clean_SqlReports_Block_Adminhtml_Report_Edit extends Mage_Adminhtml_Block_
         $this->_addButton('delete', array(
             'label'     => 'Delete',
             'onclick'   => "deleteConfirm('$confirmText', '$deleteUrl');",
-            'class'     => 'save',
+            'class'     => 'delete',
         ));
     }
 


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/4132322/10870683/7614fc4a-809e-11e5-943b-752ffaab3e1b.png)

Delete button now uses `delete` class, following Magento convention.

Resolves #41 

