### PR TITLE
Add type and alignment options

### DIFF
--- a/app/code/community/Clean/SqlReports/Block/Adminhtml/Customreport/View/Grid.php
+++ b/app/code/community/Clean/SqlReports/Block/Adminhtml/Customreport/View/Grid.php
@@ -90,10 +90,18 @@ class Clean_SqlReports_Block_Adminhtml_Customreport_View_Grid extends Mage_Admin
         $filterable = $config->getFilterable();
         $clickable  = $config->getClickable();
         $hidden     = $config->getHidden();
+        $type       = $config->getType();
+        $alignment  = $config->getAlignment();
         $items      = $collection->getItems();
+
+        $store = Mage::app()->getStore();
+        $currency_code = $store->getBaseCurrency()->getCode();
         if (count($items)) {
             $item = reset($items);
             foreach ($item->getData() as $key => $val) {
+                $column_css_class = array();
+                $header_css_class = array();
+
                 $isFilterable = false;
                 if (isset($filterable[$key])) {
                     $isFilterable = $filterable[$key];
@@ -111,7 +119,19 @@ class Clean_SqlReports_Block_Adminhtml_Customreport_View_Grid extends Mage_Admin
                 $isHidden = false;
                 if (isset($hidden[$key])) {
                     $isHidden = true;
+                    $column_css_class[] = 'no-display';
+                    $header_css_class[] = 'no-display';
                 }
+
+                if(isset($alignment[$key])) {
+                    if($alignment[$key] == 'right') {
+                        $column_css_class[] = 'a-right';
+                    }
+                    elseif($alignment[$key] == 'center') {
+                        $column_css_class[] = 'a-center';
+                    }
+                }
+
                 $this->addColumn(
                     Mage::getModel('catalog/product')->formatUrlKey($key),
                     array(
@@ -119,9 +139,11 @@ class Clean_SqlReports_Block_Adminhtml_Customreport_View_Grid extends Mage_Admin
                         'index'    => $key,
                         'filter'   => $isFilterable,
                         'sortable' => true,
+                        'type'     => (isset($type[$key]) ? $type[$key] : 'text'),
                         'renderer' => $isClickable,
-                        'column_css_class' => ($isHidden ? 'no-display' : ''),
-                        'header_css_class' => ($isHidden ? 'no-display' : ''),
+                        'column_css_class' => implode(' ', $column_css_class),
+                        'header_css_class' => implode(' ', $header_css_class),
+                        'currency_code'    => $currency_code,
                     )
                 );
             }

--- a/app/code/community/Clean/SqlReports/Model/Report/GridConfig.php
+++ b/app/code/community/Clean/SqlReports/Model/Report/GridConfig.php
@@ -40,4 +40,30 @@ class Clean_SqlReports_Model_Report_GridConfig extends Varien_Object
         return array();
     }
 
+    /**
+     * get list of columns types
+     * @return array
+     */
+    public function getType()
+    {
+        $type = $this->getData('type');
+        if (is_array($type)) {
+            return $type;
+        }
+        return array();
+    }
+
+    /**
+     * get list of columns alignment options
+     * @return array
+     */
+    public function getAlignment()
+    {
+        $alignment = $this->getData('alignment');
+        if (is_array($alignment)) {
+            return $alignment;
+        }
+        return array();
+    }
+
 }


### PR DESCRIPTION
I propose to add column type and alignment options in "Grid configuration" field for a better grid customization. For a simple example, you could render a column as currency just like:

{
"type": {
"Total": "currency"
},
"alignment": {
"Total": "right"
}
}