### PR TITLE
Export excel enhanced

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,17 @@ Here is a list of common filter block types:
 
 More can be found in `app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column.php` within the `_getFilterByType` method.
 
+The column data can be rendered using the Magento types:
+
+```json
+{  
+   "type":{  
+      "order date":"date",
+      "total_price": "currency",
+   }
+}
+```
+
 You can also create clickable row values, and hide columns. Example;
 
 ```json
@@ -83,6 +94,10 @@ You can also create clickable row values, and hide columns. Example;
    },
    "hidden":{  
       "product_id":true
+   }
+   "alignment":{  
+      "sku":"center",
+      "total_price":"right"
    }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The column data can be rendered using the Magento types:
 {  
    "type":{  
       "order_date":"date",
-      "total_price": "currency",
+      "total_price":"currency",
    }
 }
 ```
@@ -94,7 +94,7 @@ You can also create clickable row values, hide columns and define alignment. Exa
    },
    "hidden":{  
       "product_id":true
-   }
+   },
    "alignment":{
       "sku":"center",
       "total_price":"right"

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ You can also create clickable row values, hide columns and define alignment. Exa
 You can export the plain tables to CSV or Excel. By default, is used the standard Magento export mechanism.
 
 If you want to export to Excel 2007 format, follow next steps:
- - Download PHPExcel library from: https://github.com/PHPOffice/PHPExcel
+ - Download PHPExcel library from https://github.com/PHPOffice/PHPExcel
  - Create the folder lib/PHPExcel
  - Copy the downloaded Classes folder to lib/PHPExcel
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ See [the contributor list](https://github.com/kalenjordan/custom-reports/graphs/
 
 #### **Known Issues**
 - Calendar Chart only supports one year.
+- "currency" column type uses the default store currency, so currency symbol can be wrong on a multiple currency store.
 
 #### **Disclaimer**
  - **Use at your own risk.**

--- a/README.md
+++ b/README.md
@@ -102,6 +102,16 @@ You can also create clickable row values, hide columns and define alignment. Exa
 }
 ```
 
+### Export
+You can export the plain tables to CSV or Excel. By default, is used the standard Magento export mechanism.
+
+If you want to export to Excel 2007 format, follow next steps:
+ - Download PHPExcel library from: https://github.com/PHPOffice/PHPExcel
+ - Create the folder lib/PHPExcel
+ - Copy the downloaded Classes folder to lib/PHPExcel
+
+If the library is found, then it will be used instead the default Magento export. In that case, cells will adjust automatically to content and the alignment definition allows to align columns in the Excel.
+
 ### License
 The license is currently <a href="https://tldrlegal.com/license/creative-commons-attribution-noncommercial-(cc-nc)#summary">Creative Commons Attribution NonCommercial</a>.  TL;DR is that you can modify and distribute but not for commercial use.
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The column data can be rendered using the Magento types:
 }
 ```
 
-You can also create clickable row values, and hide columns. Example;
+You can also create clickable row values, hide columns and define alignment. Example;
 
 ```json
 {  

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ You can also create clickable row values, hide columns and define alignment. Exa
    "hidden":{  
       "product_id":true
    }
-   "alignment":{  
+   "alignment":{
       "sku":"center",
       "total_price":"right"
    }

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The column data can be rendered using the Magento types:
 ```json
 {  
    "type":{  
-      "order date":"date",
+      "order_date":"date",
       "total_price": "currency",
    }
 }

--- a/app/code/community/Clean/SqlReports/Block/Adminhtml/Customreport/View/Grid.php
+++ b/app/code/community/Clean/SqlReports/Block/Adminhtml/Customreport/View/Grid.php
@@ -194,14 +194,8 @@ class Clean_SqlReports_Block_Adminhtml_Customreport_View_Grid extends Mage_Admin
                 }
             }
         }
-
-        /*foreach ($this->_columns as $column) {
-            if (!$column->getIsSystem()) {
-                $data[] = ''.$column->getExportHeader().'';
-            }
-        }*/
+        
         $xl_data[] = $data;
-
         foreach ($this->getCollection() as $item) {
             $data = array();
             foreach ($this->_columns as $column) {

--- a/app/code/community/Clean/SqlReports/Block/Adminhtml/Customreport/View/Grid.php
+++ b/app/code/community/Clean/SqlReports/Block/Adminhtml/Customreport/View/Grid.php
@@ -100,19 +100,12 @@ class Clean_SqlReports_Block_Adminhtml_Customreport_View_Grid extends Mage_Admin
         if (count($items)) {
             $item = reset($items);
             foreach ($item->getData() as $key => $val) {
-                $options = FALSE;
                 $column_css_class = array();
                 $header_css_class = array();
 
                 $isFilterable = false;
                 if (isset($filterable[$key])) {
                     $isFilterable = $filterable[$key];
-                    if (is_array($isFilterable) && isset($isFilterable['type']) && $isFilterable['type'] === 'adminhtml/widget_grid_column_filter_select') {
-                        $options = $this->_getFilterableOptions($isFilterable);
-                        $isFilterable = $options ? $isFilterable['type'] : 'adminhtml/widget_grid_column_filter_text';
-                    } else {
-                        $isFilterable = $filterable[$key];
-                    }
                 } elseif (in_array($key, $filterable)) {
                     $isFilterable = 'adminhtml/widget_grid_column_filter_text';
                 }
@@ -146,7 +139,6 @@ class Clean_SqlReports_Block_Adminhtml_Customreport_View_Grid extends Mage_Admin
                         'header'   => Mage::helper('core')->__($label),
                         'index'    => $key,
                         'filter'   => $isFilterable,
-                        'options'  => $options,
                         'sortable' => true,
                         'type'     => (isset($type[$key]) ? $type[$key] : 'text'),
                         'renderer' => $isClickable,
@@ -159,68 +151,6 @@ class Clean_SqlReports_Block_Adminhtml_Customreport_View_Grid extends Mage_Admin
         }
 
         return parent::_prepareColumns();
-    }
-
-    protected function _getFilterableOptions($isFilterable)
-    {
-        if (isset($isFilterable['options'])) {
-            if (is_array($isFilterable['options'])) {
-                return $isFilterable['options'];
-            }
-            return false;
-        }
-
-        if (isset($isFilterable['source_model'])) {
-            $model = Mage::getModel($isFilterable['source_model']);
-        } elseif (isset($isFilterable['resource_model'])) {
-            $model = Mage::getResourceModel($isFilterable['resource_model']);
-        }
-
-        if ($model) {
-            if (isset($isFilterable['method'])) {
-                if (!method_exists($model, $isFilterable['method'])) {
-                    return false;
-                }
-
-                $options = $model->{$isFilterable['method']}();
-                if (is_array($options)) {
-                    $fields = isset($isFilterable['option_data']) ? $isFilterable['option_data'] : false;
-                    if (is_array($fields) && isset($fields['value']) && isset($fields['label'])) {
-                        return $this->_toFlatArray($options, $fields['value'], $fields['label']);
-                    }
-                    return $this->_toFlatArray($options);
-                }
-                return false;
-            }
-
-            // Magento fallback
-            if (method_exists($model, 'toOptionArray')) {
-                return $this->_toFlatArray($model->toOptionArray());
-            } elseif (method_exists($model, 'getOptionArray')) {
-                return $this->_toFlatArray($model->getOptionArray());
-            }
-        }
-        return false;
-    }
-
-    protected function _toFlatArray($options, $value = 'value', $label = 'label')
-    {
-        if (!is_array($options)) {
-            return false;
-        }
-
-        if (!is_array(reset($options))) {
-            return $options;
-        }
-
-        if (isset($options[key($options)][$value]) && isset($options[key($options)][$label])) {
-            foreach ($options as $key => $option) {
-                $options[$option[$value]] = $option[$label];
-                unset($options[$key]);
-            }
-            return $options;
-        }
-        return false;
     }
 
     public function getExcel2007Data()

--- a/app/code/community/Clean/SqlReports/Block/Adminhtml/Customreport/View/Grid.php
+++ b/app/code/community/Clean/SqlReports/Block/Adminhtml/Customreport/View/Grid.php
@@ -153,6 +153,11 @@ class Clean_SqlReports_Block_Adminhtml_Customreport_View_Grid extends Mage_Admin
         return parent::_prepareColumns();
     }
 
+    /**
+     * Get the array with all data to export, including header.
+     * 
+     * @return array
+     */
     public function getExcel2007Data()
     {
         $this->_isExport = true;

--- a/app/code/community/Clean/SqlReports/Model/Report/GridConfig.php
+++ b/app/code/community/Clean/SqlReports/Model/Report/GridConfig.php
@@ -40,4 +40,30 @@ class Clean_SqlReports_Model_Report_GridConfig extends Varien_Object
         return array();
     }
 
+    /**
+     * get list of columns types
+     * @return array
+     */
+    public function getType()
+    {
+        $type = $this->getData('type');
+        if (is_array($type)) {
+            return $type;
+        }
+        return array();
+    }
+
+    /**
+     * get list of columns alignment options
+     * @return array
+     */
+    public function getAlignment()
+    {
+        $alignment = $this->getData('alignment');
+        if (is_array($alignment)) {
+            return $alignment;
+        }
+        return array();
+    }
+
 }

--- a/app/code/community/Clean/SqlReports/controllers/Adminhtml/CustomreportController.php
+++ b/app/code/community/Clean/SqlReports/controllers/Adminhtml/CustomreportController.php
@@ -115,6 +115,153 @@ class Clean_SqlReports_Adminhtml_CustomreportController extends Mage_Adminhtml_C
     }
 
     /**
+     * Export grid to Excel format
+     */
+    public function exportExcelAction()
+    {
+        if ($this->_isPhpExcelAvailable()) {
+            $this->_exportToXlsx();
+        }
+        else {
+            $this->_exportToXls();
+        }
+    }
+
+    /**
+     * Export grid to Excel XLS format
+     */
+    protected function _exportToXls()
+    {
+        Mage::register('current_report', $this->_getReport());
+        $this->loadLayout();
+
+        /** @var $grid Mage_Adminhtml_Block_Widget_Grid */
+        $grid = $this->getLayout()->getBlock('report.view.grid');
+
+        if(!$grid instanceof Mage_Adminhtml_Block_Widget_Grid) {
+            $this->_forward('noroute');
+            return;
+        }
+
+        $fileName = strtolower(str_replace(' ', '_', $this->_getReport()->getTitle())) . '_' . time() . '.xls';
+        $content  = $grid->getExcel($fileName);
+
+        $this->_prepareDownloadResponse(
+            $fileName,
+            $content
+        );
+    }
+
+    /**
+     * Export grid to Excel XLSX format
+     *
+     * Requires an external library:
+     *      - Download library from: https://github.com/PHPOffice/PHPExcel
+     *      - Create the folder lib/PHPExcel
+     *      - Copy the downloaded Classes folder to lib/PHPExcel
+     */
+    protected function _exportToXlsx()
+    {
+        Mage::register('current_report', $this->_getReport());
+        $this->loadLayout();
+
+        /** @var $grid Mage_Adminhtml_Block_Widget_Grid */
+        $grid = $this->getLayout()->getBlock('report.view.grid');
+
+        if(!$grid instanceof Mage_Adminhtml_Block_Widget_Grid) {
+            $this->_forward('noroute');
+            return;
+        }
+
+        $config     = $this->_getReport()->getGridConfig();
+        $alignment  = $config->getAlignment();
+
+        $fileName = strtolower(str_replace(' ', '_', $this->_getReport()->getTitle())) . '_' . time() . '.xlsx';
+        $worksheet_name = $this->_getReport()->getTitle();
+        $content  = $grid->getExcel2007Data();
+
+        include $this->_getPhpExcelPath();
+        $objPHPExcel = new PHPExcel();
+
+        $rowCount = 1;
+        $maxCol = 0;
+        $column_alignment = array();
+        foreach($content as $value){
+            $column = 'A';
+            $maxCol = 0;
+            foreach($value as $val){
+
+                if ($rowCount == 1) {
+                    $objPHPExcel->setActiveSheetIndex(0)->setCellValue($column.$rowCount, $val['label']);
+
+                    if(isset($alignment[$val['key']])) {
+                        $column_alignment[] = array('column' => $column, 'alignment' => $alignment[$val['key']]);
+                    }
+                }
+                else {
+                    $objPHPExcel->setActiveSheetIndex(0)->setCellValue($column.$rowCount, $val);
+                }
+
+                $column++;
+                $maxCol++;
+            }
+
+            $rowCount++;
+        }
+
+        // Columns alignment
+        foreach($column_alignment as $value){
+            $column = $value['column'];
+            $cell_alignment = $value['alignment'];
+            if($cell_alignment == 'right') {
+                $objPHPExcel->getActiveSheet()->getStyle($column.'1:'.$column.$rowCount)
+                     ->getAlignment()
+                     ->setHorizontal(PHPExcel_Style_Alignment::HORIZONTAL_RIGHT);
+            }
+            elseif($cell_alignment == 'center') {
+                $objPHPExcel->getActiveSheet()->getStyle($column.'1:'.$column.$rowCount)
+                     ->getAlignment()
+                     ->setHorizontal(PHPExcel_Style_Alignment::HORIZONTAL_CENTER);
+            }
+        }
+
+        // Auto-size width
+        for($column_index = 0; $column_index <= $maxCol; $column_index++) {
+            $objPHPExcel->getActiveSheet()->getColumnDimension(PHPExcel_Cell::stringFromColumnIndex($column_index))->setAutoSize(true);
+        }
+
+        $objPHPExcel->getActiveSheet()->setTitle($worksheet_name);
+        $objPHPExcel->setActiveSheetIndex(0);
+
+        // Redirect output to a client’s web browser (Excel2007)
+        header('Content-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+        header("Content-Disposition: attachment;filename=$fileName");
+        header('Cache-Control: max-age=0');
+        $objWriter = PHPExcel_IOFactory::createWriter($objPHPExcel, 'Excel2007');
+        $objWriter->save('php://output');
+    }
+
+    /**
+     * Check if library PHPExcel is available.
+     *
+     * @return boolean
+     */
+    protected function _isPhpExcelAvailable()
+    {
+        return file_exists($this->_getPhpExcelPath());
+    }
+
+    /**
+     * Get the PHPExcel library path.
+     *
+     * @return string
+     */
+    protected function _getPhpExcelPath()
+    {
+        return Mage::getBaseDir("lib") . DS . "PHPExcel" . DS . "Classes" . DS ."PHPExcel.php";
+    }
+
+    /**
      * Get JSON action
      *
      * @return void
@@ -156,7 +303,7 @@ class Clean_SqlReports_Adminhtml_CustomreportController extends Mage_Adminhtml_C
 
     protected function _isAllowed()
     {
-        $isView = in_array($this->getRequest()->getActionName(), array('index', 'view', 'viewtable', 'viewchart', 'getJson', 'exportCsv'));
+        $isView = in_array($this->getRequest()->getActionName(), array('index', 'view', 'viewtable', 'viewchart', 'getJson', 'exportCsv', 'exportExcel'));
 
         /** @var $helper Clean_SqlReport_Helper_Data */
         $helper = Mage::helper('cleansql');

--- a/app/code/community/Clean/SqlReports/controllers/Adminhtml/CustomreportController.php
+++ b/app/code/community/Clean/SqlReports/controllers/Adminhtml/CustomreportController.php
@@ -156,9 +156,9 @@ class Clean_SqlReports_Adminhtml_CustomreportController extends Mage_Adminhtml_C
      * Export grid to Excel XLSX format
      *
      * Requires an external library:
-     *      - Download library from: https://github.com/PHPOffice/PHPExcel
-     *      - Create the folder lib/PHPExcel
-     *      - Copy the downloaded Classes folder to lib/PHPExcel
+     *      - Download library from https://github.com/PHPOffice/PHPExcel
+     *      - Create the folder 'lib/PHPExcel'
+     *      - Copy the downloaded 'Classes' folder to 'lib/PHPExcel'
      */
     protected function _exportToXlsx()
     {

--- a/app/design/adminhtml/default/default/layout/clean_sqlreports/cleansql.xml
+++ b/app/design/adminhtml/default/default/layout/clean_sqlreports/cleansql.xml
@@ -59,5 +59,9 @@
         <update handle="adminhtml_adminhtml_customreport_viewtable"/>
     </adminhtml_adminhtml_customreport_exportcsv>
 
+    <adminhtml_adminhtml_customreport_exportexcel>
+        <update handle="adminhtml_adminhtml_customreport_viewtable"/>
+    </adminhtml_adminhtml_customreport_exportexcel>
+
 </layout>
 


### PR DESCRIPTION
This pull request contains #78 and #79 requests, as the previous changes are required to improve export to Excel in 2007 format.

README.md is updated for a better information about new feature which in a brief are:

- Column type definition
- Column alignment
- Export to Excel
- Export to Excel 2007 if PHPExcel is in 'lib' folder. When this option is available, column alignment is used also in Excel. More of the current definition could be used in this kind of Excel, if there is interest on it.

#### **TO DO**
- Improve Excel 2007 algorithm (at least, refactor and reduce complexity)
- Try to obtain `currency_code` from a selectable field to allow show prices accordingly to stored currency for each transaction. Current implementation is valid only for stores with one currency.